### PR TITLE
Docker releaser reusable workflow

### DIFF
--- a/.github/workflows/common-docker-releaser.yaml
+++ b/.github/workflows/common-docker-releaser.yaml
@@ -1,0 +1,32 @@
+name: Release image
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  release:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.token }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ inputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This is suppose to be standard way to release a Docker image so we do not have to recreate pipelines.