### PR TITLE
Add arm64 as platform

### DIFF
--- a/.github/workflows/common-docker-releaser.yaml
+++ b/.github/workflows/common-docker-releaser.yaml
@@ -32,4 +32,5 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ inputs.tags }}
           cache-from: type=gha
+          platforms: linux/amd64,linux/arm64
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Since I run my homelab on raspberry pi 4 I needed this image to run on arm64. My currently forked image does that thanks to this change.

https://github.com/Toasterson/powerdns-docker/pkgs/container/powerdns-docker%2Fpowerdns

Upstreaming this in the hope it helps others.